### PR TITLE
🐛 Fix ByteData import

### DIFF
--- a/lib/synthesizer.dart
+++ b/lib/synthesizer.dart
@@ -4,6 +4,7 @@
 
 
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'soundfont.dart';
 import 'channel.dart';


### PR DESCRIPTION
Error was 'type not found'.
Fixes #3 