### PR TITLE
Fix stereo audio audio_renderer_ex.dart

### DIFF
--- a/lib/audio_renderer_ex.dart
+++ b/lib/audio_renderer_ex.dart
@@ -103,7 +103,7 @@ extension AudioRenderEx on Synthesizer
         if (length != null) {
           sampleCount = length;
         } else {
-          sampleCount = destination.bytes.lengthInBytes ~/ 2;
+          sampleCount = destination.bytes.lengthInBytes ~/ 4;
           sampleCount -= offset;
         }
 
@@ -118,7 +118,7 @@ extension AudioRenderEx on Synthesizer
             var sampleRight = (32768 * right[t]).toInt();
 
             // these get automaticall casted to shorts in ArrayInt16[]
-            destination[offset + t * 2 + 1] = sampleLeft;
+            destination[offset + t * 2 + 0] = sampleLeft;
             destination[offset + t * 2 + 1] = sampleRight;
         }
     }


### PR DESCRIPTION
Hey,

Mono works, but stereo is broken.
I use this code for my stereo, and it works.

This function is broken. The division by 2 does not fit the stereo bits. The % 4 is checked in the start but accidentally division by 2 is used for the sample amount. Also the left and right sample go to the same destination index by mistake.

NB! I do not use offset, so I do not know whether that is calculated correctly in this one.

Thanks!