### PR TITLE
Fix for instrument & preset name having garbage characters

### DIFF
--- a/lib/binary_reader.dart
+++ b/lib/binary_reader.dart
@@ -149,10 +149,14 @@ class BinaryReader
         byteList[i] = data.getUint8(i);
       }
 
-      String out = String.fromCharCodes(byteList);
+      // Find null terminator and trim the string until the first occurrence of it
+      int actualLength = byteList.indexOf(0);
+      if (actualLength == -1) {
+         // Take the whole string if not found
+        actualLength = length;
+      }
 
-      // remove null characters
-      out = String.fromCharCodes(out.codeUnits.where((code) => code != 0));
+      String out = String.fromCharCodes(byteList.getRange(0, actualLength));
 
       return out;
   }


### PR DESCRIPTION
Plenty of soundfonts like [Airfont 380](https://musical-artifacts.com/artifacts/635) and [Ntonyx's 32MBGMStereo](http://ntonyx.com/soft/32MbGMStereo.sf2) have corrupted names for instruments and presets when loaded. The reason is those names that are beyond 20-character limit has uninitialized characters past their null character (ASCII code 0)

![Screenshot 2024-10-26 at 9 24 49 PM](https://github.com/user-attachments/assets/f3d91b73-9fa2-42a6-8c36-557a401fc7c7)

This PR fixes the logic to ensure the name reading terminates on null character properly. Any extra characters beyond the null character will be discarded.