### PR TITLE
Fix sounds losing value on certain Soundfont samples 

### DIFF
--- a/lib/modulation_envelope.dart
+++ b/lib/modulation_envelope.dart
@@ -47,6 +47,9 @@ class ModulationEnvelope
       _releaseEndTime = release;
       _sustainLevel = sustain.clamp(0.0, 1.0);
       _releaseLevel = 0;
+      _processedSampleCount = 0;
+      _stage = EnvelopeStage.delay;
+      _value = 0;
 
       _process(0);
     }


### PR DESCRIPTION
### Issue
- On certain soundfont file and certain instrument, the sound it plays will lose its volume/attack over time. This retains even after stopping or restarting synth playback.
- Examples:  [8MBGMSFX.sf2](https://github.com/exeex/mimi/blob/master/mimi/soundfont/8MBGMSFX.SF2)'s Grand Piano sound (less obvious) and [4gmgsmt](https://archive.org/download/free-soundfonts-sf2-2019-04/Creative%20Labs%204M%20GM_4gmgsmt.sf2)'s Piano 1 sound (more noticeable after playing 3-4 notes)

### Causes
- Voices are reused, but modulation envelope state are not initialized properly on start, most notably `EnvelopeStage`. It will stuck on `EnvelopeStage.release` forever.  


### Fixes
- I added the missing lines on ModulationEnvelope class from sinshu's [meltysynth](https://github.com/sinshu/meltysynth/blob/main/MeltySynth/src/ModulationEnvelope.cs) repo