### PR TITLE
Add MIDI file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,37 @@ synth.noteOff(channel: 0, key: 72, velocity: 120);
 synth.renderMonoInt16(buf16);
 ```
 
+Synthesize notes from a MIDI file playback:
+
+```dart
+// Necessary imports
+import 'package:dart_melty_soundfont/dart_melty_soundfont.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+// Load the soundfont file
+ByteData bytes = await rootBundle.load('assets/akai_steinway.sf2');
+
+// Create the synthesizer
+Synthesizer synth = Synthesizer.loadByteData(bytes);
+
+// Load MIDI file from asset
+ByteData midiBytes = await rootBundle.load('assets/arabesque.mid');
+MidiFile midiFile = MidiFile.fromByteData(midiBytes);
+
+// Start MIDI playback
+MidiFileSequencer sequencer = MidiFileSequencer(synth);
+sequencer.play(midiFile, loop: false);
+
+// Change the playback speed.
+sequencer.speed = 1.5;
+
+// Render 10 seconds of playback into PCM buffer
+ArrayInt16 buf16 = ArrayInt16.zeros(numShorts: 44100 * 10);
+synth.renderMonoInt16(buf16);
+
+```
+
+
 ## Playing Sound
 
 This library does not audibly make sound, it only generates the PCM waveform. 
@@ -106,8 +137,9 @@ It is recommended to do your audio rendering in isolates or using [`compute`](ht
     - [x] Reverb
     - [x] Chorus
 * __Other things__
+    - [x] Standard MIDI file support
     - [x] Loop extension support
-    - [x] Performace optimization
+    - [x] Performance optimization
 
 ## License
 

--- a/lib/audio_renderer.dart
+++ b/lib/audio_renderer.dart
@@ -1,0 +1,15 @@
+/// <summary>
+/// Defines a common interface for audio rendering.
+/// </summary>
+abstract class AudioRenderer {
+
+  /// <summary>
+  /// Renders the waveform.
+  /// </summary>
+  /// <param name="left">The buffer of the left channel to store the rendered waveform.</param>
+  /// <param name="right">The buffer of the right channel to store the rendered waveform.</param>
+  /// <remarks>
+  /// The output buffers for the left and right must be the same length.
+  /// </remarks>
+  void render(List<double> left, List<double> right);
+}

--- a/lib/audio_renderer_ex.dart
+++ b/lib/audio_renderer_ex.dart
@@ -5,12 +5,12 @@
 
 
 
-import 'synthesizer.dart';
+import 'audio_renderer.dart';
 import 'array_int16.dart';
 
 
 /// Provides utility methods to convert the format of samples.
-extension AudioRenderEx on Synthesizer
+extension AudioRenderEx on AudioRenderer
 {
     /// <summary>
     /// Renders the waveform as a stereo interleaved signal.

--- a/lib/dart_melty_soundfont.dart
+++ b/lib/dart_melty_soundfont.dart
@@ -1,5 +1,7 @@
 export 'synthesizer.dart';
 export 'synthesizer_settings.dart';
+export 'midi_file.dart';
+export 'midi_file_sequencer.dart';
 export 'preset.dart';
 export 'audio_renderer_ex.dart';
 export 'array_int16.dart';

--- a/lib/list_slice.dart
+++ b/lib/list_slice.dart
@@ -5,22 +5,34 @@ import 'dart:collection';
 class ListSlice<E> extends ListBase<E> {
   final List<E> _list;
   final int start;
+  final int _length;
+
+  ListSlice(this._list, this.start, int length)
+      : assert(start + length <= _list.length, "Slice length must be less than list length"),
+        _length = length;
 
   @override
-  int length;
+  int get length => _length;
 
-  ListSlice(this._list, this.start, this.length): assert(start + length <= _list.length, "Slice length must be less than list length");
+  set length(int value) => throw UnsupportedError('Setting length is not supported on list slice');
 
   @override
   E operator [](int index) {
+    if (index < 0 || index >= length) {
+      throw RangeError.index(index, this); // Check bounds
+    }
     return _list[index + start];
   }
 
   @override
   void operator []=(int index, E value) {
+    if (index < 0 || index >= length) {
+      throw RangeError.index(index, this); // Check bounds
+    }
     _list[index + start] = value;
   }
 }
+
 
 extension ListSliceExtension<E> on List<E> {
   ListSlice<E> slice(int start, int length) {

--- a/lib/list_slice.dart
+++ b/lib/list_slice.dart
@@ -1,0 +1,29 @@
+import 'dart:collection';
+
+/// Minimal implementation of C# list slices in Dart
+/// Allows reading and writing to the backed list
+class ListSlice<E> extends ListBase<E> {
+  final List<E> _list;
+  final int start;
+
+  @override
+  int length;
+
+  ListSlice(this._list, this.start, this.length): assert(start + length <= _list.length, "Slice length must be less than list length");
+
+  @override
+  E operator [](int index) {
+    return _list[index + start];
+  }
+
+  @override
+  void operator []=(int index, E value) {
+    _list[index + start] = value;
+  }
+}
+
+extension ListSliceExtension<E> on List<E> {
+  ListSlice<E> slice(int start, int length) {
+    return ListSlice(this, start, length);
+  }
+}

--- a/lib/midi_file.dart
+++ b/lib/midi_file.dart
@@ -12,22 +12,20 @@ class MidiFile {
   late List<Duration> _times;
 
   /// Loads a MIDI file from the file path.
-  factory MidiFile.fromFile(String path,
-      [int? loopPoint, MidiFileLoopType? loopType]) {
+  factory MidiFile.fromFile(String path, {int? loopPoint, MidiFileLoopType? loopType}) {
     BinaryReader reader = BinaryReader.fromFile(path);
 
-    return MidiFile(reader, loopPoint, loopType);
+    return MidiFile.fromBinaryReader(reader, loopPoint: loopPoint, loopType: loopType);
   }
 
   /// Loads a MIDI file from the byte data
-  factory MidiFile.fromByteData(ByteData bytes,
-      [int? loopPoint, MidiFileLoopType? loopType]) {
+  factory MidiFile.fromByteData(ByteData bytes, {int? loopPoint, MidiFileLoopType? loopType}) {
     BinaryReader reader = BinaryReader.fromByteData(bytes);
 
-    return MidiFile(reader, loopPoint, loopType);
+    return MidiFile.fromBinaryReader(reader, loopPoint: loopPoint, loopType: loopType);
   }
 
-  MidiFile(BinaryReader reader, [int? loopPoint, MidiFileLoopType? loopType]) {
+  MidiFile.fromBinaryReader(BinaryReader reader, {int? loopPoint, MidiFileLoopType? loopType}) {
     if (loopPoint != null && loopPoint < 0) {
       throw "The loop point must be a non-negative value.";
     }

--- a/lib/midi_file.dart
+++ b/lib/midi_file.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:dart_melty_soundfont/binary_reader.dart';
-
+import 'binary_reader.dart';
 import 'midi_file_loop_type.dart';
 
 /// <summary>

--- a/lib/midi_file.dart
+++ b/lib/midi_file.dart
@@ -1,0 +1,395 @@
+import 'dart:typed_data';
+
+import 'package:dart_melty_soundfont/binary_reader.dart';
+
+import 'midi_file_loop_type.dart';
+
+/// <summary>
+/// Represents a standard MIDI file.
+/// </summary>
+class MidiFile {
+  late List<MidiMessage> _messages;
+  late List<Duration> _times;
+
+  /// Loads a MIDI file from the file path.
+  factory MidiFile.fromFile(String path,
+      [int? loopPoint, MidiFileLoopType? loopType]) {
+    BinaryReader reader = BinaryReader.fromFile(path);
+
+    return MidiFile(reader, loopPoint, loopType);
+  }
+
+  /// Loads a MIDI file from the byte data
+  factory MidiFile.fromByteData(ByteData bytes,
+      [int? loopPoint, MidiFileLoopType? loopType]) {
+    BinaryReader reader = BinaryReader.fromByteData(bytes);
+
+    return MidiFile(reader, loopPoint, loopType);
+  }
+
+  MidiFile(BinaryReader reader, [int? loopPoint, MidiFileLoopType? loopType]) {
+    if (loopPoint != null && loopPoint < 0) {
+      throw "The loop point must be a non-negative value.";
+    }
+
+    _load(reader, loopPoint ?? 0, loopType ?? MidiFileLoopType.none);
+  }
+
+  static Duration getTimeSpanFromSeconds(double value) {
+    return Duration(
+        microseconds: (value * Duration.microsecondsPerSecond).round());
+  }
+
+  void _load(BinaryReader reader, int loopPoint, MidiFileLoopType loopType) {
+    final chunkType = reader.readFourCC();
+    if (chunkType != "MThd") {
+      throw "The chunk type must be 'MThd', but was '$chunkType'.";
+    }
+
+    final size = reader.readInt32BigEndian();
+    if (size != 6) {
+      throw "The MThd chunk has invalid data.";
+    }
+
+    final format = reader.readInt16BigEndian();
+    if (!(format == 0 || format == 1)) {
+      throw "The format {format} is not supported.";
+    }
+
+    final trackCount = reader.readInt16BigEndian();
+    final resolution = reader.readInt16BigEndian();
+
+    final messageLists = List<List<MidiMessage>>.filled(trackCount, [], growable: false);
+    final tickLists = List<List<int>>.filled(trackCount, [], growable: false);
+
+    for (int i = 0; i < trackCount; i++) {
+      final tracks = _readTrack(reader, loopType);
+      messageLists[i] = tracks.messages;
+      tickLists[i] = tracks.ticks;
+    }
+
+    if (loopPoint != 0) {
+      final tickList = tickLists[0];
+      final messageList = messageLists[0];
+      if (loopPoint <= tickList.last) {
+        for (int i = 0; i < tickList.length; i++) {
+          if (tickList[i] >= loopPoint) {
+            tickList.insert(i, loopPoint);
+            messageList.insert(i, MidiMessage.loopStart());
+            break;
+          }
+        }
+      } else {
+        tickList.add(loopPoint);
+        messageList.add(MidiMessage.loopStart());
+      }
+    }
+
+    final mergedTracks = _mergeTracks(messageLists, tickLists, resolution);
+    _messages = mergedTracks.messages;
+    _times = mergedTracks.times;
+  }
+
+  static _MidiMessagesAndTicks _readTrack(
+      BinaryReader reader, MidiFileLoopType loopType) {
+    final chunkType = reader.readFourCC();
+    if (chunkType != "MTrk") {
+      throw "The chunk type must be 'MTrk', but was '$chunkType'.";
+    }
+
+    int end = reader.readInt32BigEndian();
+    end += reader.pos;
+
+    final messages = <MidiMessage>[];
+    final ticks = <int>[];
+
+    int tick = 0;
+    int lastStatus = 0;
+
+    while (true) {
+      final delta = reader.readMidiVariablelength();
+      final first = reader.readUInt8();
+
+      try {
+        tick = tick + delta;
+      } catch (OverflowException) {
+        throw "Long MIDI file is not supported.";
+      }
+
+      if ((first & 128) == 0) {
+        final command = lastStatus & 0xF0;
+        if (command == 0xC0 || command == 0xD0) {
+          messages.add(MidiMessage.common(lastStatus, first));
+          ticks.add(tick);
+        } else {
+          final data2 = reader.readUInt8();
+          messages.add(MidiMessage.common(lastStatus, first, data2, loopType));
+          ticks.add(tick);
+        }
+
+        continue;
+      }
+
+      switch (first) {
+        case 0xF0: // System Exclusive
+          _discardData(reader);
+          break;
+
+        case 0xF7: // System Exclusive
+          _discardData(reader);
+          break;
+
+        case 0xFF: // Meta Event
+          switch (reader.readUInt8()) {
+            case 0x2F: // End of Track
+              reader.readUInt8();
+              messages.add(MidiMessage.endOfTrack());
+              ticks.add(tick);
+
+              // Some MIDI files may have events inserted after the EOT.
+              // Such events should be ignored.
+              if (reader.pos < end) {
+                reader.pos = end;
+              }
+
+              return _MidiMessagesAndTicks(messages, ticks);
+
+            case 0x51: // Tempo
+              messages.add(MidiMessage.tempoChange(_readTempo(reader)));
+              ticks.add(tick);
+              break;
+
+            default:
+              _discardData(reader);
+              break;
+          }
+          break;
+
+        default:
+          final command = first & 0xF0;
+          if (command == 0xC0 || command == 0xD0) {
+            final data1 = reader.readUInt8();
+            messages.add(MidiMessage.common(first, data1));
+            ticks.add(tick);
+          } else {
+            final data1 = reader.readUInt8();
+            final data2 = reader.readUInt8();
+            messages.add(MidiMessage.common(first, data1, data2, loopType));
+            ticks.add(tick);
+          }
+          break;
+      }
+
+      lastStatus = first;
+    }
+  }
+
+  static _MidiMessagesAndTimes _mergeTracks(
+      List<List<MidiMessage>> messageLists,
+      List<List<int>> tickLists,
+      int resolution) {
+    final mergedMessages = <MidiMessage>[];
+    final mergedTimes = <Duration>[];
+
+    final indices = List<int>.filled(messageLists.length, 0, growable: false);
+
+    int currentTick = 0;
+    Duration currentTime = Duration.zero;
+
+    double tempo = 120.0;
+
+    while (true) {
+      int minTick = 0x7fffffffffffffff; // int max value
+      int minIndex = -1;
+      for (int ch = 0; ch < tickLists.length; ch++) {
+        if (indices[ch] < tickLists[ch].length) {
+          final tick = tickLists[ch][indices[ch]];
+          if (tick < minTick) {
+            minTick = tick;
+            minIndex = ch;
+          }
+        }
+      }
+
+      if (minIndex == -1) {
+        break;
+      }
+
+      final nextTick = tickLists[minIndex][indices[minIndex]];
+      final deltaTick = nextTick - currentTick;
+      final deltaTime =
+      getTimeSpanFromSeconds(60.0 / (resolution * tempo) * deltaTick);
+
+      currentTick += deltaTick;
+      currentTime += deltaTime;
+
+      final message = messageLists[minIndex][indices[minIndex]];
+      if (message.type == MidiMessageType.tempoChange) {
+        tempo = message.tempo;
+      } else {
+        mergedMessages.add(message);
+        mergedTimes.add(currentTime);
+      }
+
+      indices[minIndex]++;
+    }
+
+    return _MidiMessagesAndTimes(mergedMessages, mergedTimes);
+  }
+
+  static int _readTempo(BinaryReader reader) {
+    final size = reader.readMidiVariablelength();
+    if (size != 3) {
+      throw "Failed to read the tempo value.";
+    }
+
+    final b1 = reader.readUInt8();
+    final b2 = reader.readUInt8();
+    final b3 = reader.readUInt8();
+    return (b1 << 16) | (b2 << 8) | b3;
+  }
+
+  static void _discardData(BinaryReader reader) {
+    final size = reader.readMidiVariablelength();
+    reader.pos += size;
+  }
+
+  /// <summary>
+  /// The length of the MIDI file.
+  /// </summary>
+  Duration get length => _times.last;
+
+  List<MidiMessage> get messages => _messages;
+
+  List<Duration> get times => _times;
+}
+
+class MidiMessage {
+  final int channel;
+  final int command;
+  final int data1;
+  final int data2;
+
+  MidiMessage._(this.channel, this.command, this.data1, this.data2);
+
+  factory MidiMessage.common(int status, int data1,
+      [int data2 = 0, MidiFileLoopType loopType = MidiFileLoopType.none]) {
+    final channel = status & 0x0F;
+    final command = status & 0xF0;
+
+    if (command == 0xB0) {
+      switch (loopType) {
+        case MidiFileLoopType.rpgMaker:
+          if (data1 == 111) {
+            return MidiMessage.loopStart();
+          }
+          break;
+
+        case MidiFileLoopType.incredibleMachine:
+          if (data1 == 110) {
+            return MidiMessage.loopStart();
+          }
+          if (data1 == 111) {
+            return MidiMessage.loopEnd();
+          }
+          break;
+
+        case MidiFileLoopType.finalFantasy:
+          if (data1 == 116) {
+            return MidiMessage.loopStart();
+          }
+          if (data1 == 117) {
+            return MidiMessage.loopEnd();
+          }
+          break;
+
+        default:
+      }
+    }
+
+    return MidiMessage._(channel, command, data1, data2);
+  }
+
+  factory MidiMessage.tempoChange(int tempo) {
+    final command = tempo >> 16;
+    final data1 = tempo >> 8;
+    final data2 = tempo;
+    return MidiMessage._(
+        MidiMessageType.tempoChange.value, command, data1, data2);
+  }
+
+  factory MidiMessage.loopStart() {
+    return MidiMessage._(MidiMessageType.loopStart.value, 0, 0, 0);
+  }
+
+  factory MidiMessage.loopEnd() {
+    return MidiMessage._(MidiMessageType.loopEnd.value, 0, 0, 0);
+  }
+
+  factory MidiMessage.endOfTrack() {
+    return MidiMessage._(MidiMessageType.endOfTrack.value, 0, 0, 0);
+  }
+
+  @override
+  String toString() {
+    switch (type) {
+      case MidiMessageType.tempoChange:
+        return "Tempo: $tempo";
+      case MidiMessageType.loopStart:
+        return "LoopStart";
+      case MidiMessageType.loopEnd:
+        return "LoopEnd";
+      case MidiMessageType.endOfTrack:
+        return "EndOfTrack";
+      default:
+        return "CH$channel: ${_toHexString(command)}, ${_toHexString(data1)}, ${_toHexString(data2)}";
+    }
+  }
+
+  String _toHexString(int value) {
+    return value.toRadixString(16).toUpperCase().padLeft(2, '0');
+  }
+
+  MidiMessageType get type {
+    // Using normal if-else as MessageType is not an enum
+    if (channel == MidiMessageType.tempoChange.value) {
+      return MidiMessageType.tempoChange;
+    } else if (channel == MidiMessageType.loopStart.value) {
+      return MidiMessageType.loopStart;
+    } else if (channel == MidiMessageType.loopEnd) {
+      return MidiMessageType.loopEnd;
+    } else if (channel == MidiMessageType.endOfTrack) {
+      return MidiMessageType.endOfTrack;
+    } else {
+      return MidiMessageType.normal;
+    }
+  }
+
+  double get tempo => 60000000.0 / ((command << 16) | (data1 << 8) | data2);
+}
+
+class MidiMessageType {
+  static const normal = MidiMessageType(0);
+  static const tempoChange = MidiMessageType(252);
+  static const loopStart = MidiMessageType(253);
+  static const loopEnd = MidiMessageType(254);
+  static const endOfTrack = MidiMessageType(255);
+
+  final int value;
+
+  const MidiMessageType(this.value);
+}
+
+class _MidiMessagesAndTicks {
+  final List<MidiMessage> messages;
+  final List<int> ticks;
+
+  _MidiMessagesAndTicks(this.messages, this.ticks);
+}
+
+class _MidiMessagesAndTimes {
+  final List<MidiMessage> messages;
+  final List<Duration> times;
+
+  _MidiMessagesAndTimes(this.messages, this.times);
+}

--- a/lib/midi_file.dart
+++ b/lib/midi_file.dart
@@ -380,6 +380,8 @@ class MidiMessageType {
   const MidiMessageType(this.value);
 }
 
+// As Dart 2.x does not have tuples (records) yet, using classes as an alternative
+
 class _MidiMessagesAndTicks {
   final List<MidiMessage> messages;
   final List<int> ticks;

--- a/lib/midi_file_loop_type.dart
+++ b/lib/midi_file_loop_type.dart
@@ -1,0 +1,28 @@
+/// <summary>
+/// Specifies the non-standard loop extension for MIDI files.
+/// </summary>
+enum MidiFileLoopType
+{
+    /// <summary>
+    /// No loop extension is used.
+    /// </summary>
+    none,
+
+    /// <summary>
+    /// The RPG Maker style loop.
+    /// CC #111 will be the loop start point.
+    /// </summary>
+    rpgMaker,
+
+    /// <summary>
+    /// The Incredible Machine style loop.
+    /// CC #110 and #111 will be the start and end points of the loop.
+    /// </summary>
+    incredibleMachine,
+
+    /// <summary>
+    /// The Final Fantasy style loop.
+    /// CC #116 and #117 will be the start and end points of the loop.
+    /// </summary>
+    finalFantasy
+}

--- a/lib/midi_file_sequencer.dart
+++ b/lib/midi_file_sequencer.dart
@@ -166,7 +166,7 @@ class MidiFileSequencer implements AudioRenderer {
 
   set speed(double value) {
     if (value >= 0) {
-      speed = value;
+      _speed = value;
     } else {
       throw "The playback speed must be a non-negative value.";
     }

--- a/lib/midi_file_sequencer.dart
+++ b/lib/midi_file_sequencer.dart
@@ -1,0 +1,190 @@
+import 'package:dart_melty_soundfont/audio_renderer.dart';
+import 'package:dart_melty_soundfont/list_slice.dart';
+
+import 'midi_file.dart';
+import 'synthesizer.dart';
+import 'dart:math' as math;
+
+/// <summary>
+/// An instance of the MIDI file sequencer.
+/// </summary>
+/// <remarks>
+/// Note that this class does not provide thread safety.
+/// If you want to control playback and render the waveform in separate threads,
+/// you must make sure that the methods are not called at the same time.
+/// </remarks>
+class MidiFileSequencer implements AudioRenderer {
+  final Synthesizer synthesizer;
+
+  double _speed = 1.0;
+
+  MidiFile? _midiFile;
+  bool? _loop;
+
+  int _blockWrote = 0;
+
+  Duration _currentTime = Duration.zero;
+  int _msgIndex = 0;
+  int _loopIndex = 0;
+
+  MessageHook? onSendMessage;
+
+  /// <summary>
+  /// Initializes a new instance of the sequencer.
+  /// </summary>
+  /// <param name="synthesizer">The synthesizer to be used by the sequencer.</param>
+  MidiFileSequencer(this.synthesizer);
+
+  /// <summary>
+  /// Plays the MIDI file.
+  /// </summary>
+  /// <param name="midiFile">The MIDI file to be played.</param>
+  /// <param name="loop">If <c>true</c>, the MIDI file loops after reaching the end.</param>
+  void play(MidiFile midiFile, {required bool loop}) {
+    _midiFile = midiFile;
+    _loop = loop;
+
+    _blockWrote = synthesizer.blockSize;
+
+    _currentTime = Duration.zero;
+    _msgIndex = 0;
+    _loopIndex = 0;
+
+    synthesizer.reset();
+  }
+
+  /// <summary>
+  /// Stops playing.
+  /// </summary>
+  void stop() {
+    _midiFile = null;
+
+    synthesizer.reset();
+  }
+
+  /// <inheritdoc/>
+  void render(List<double> left, List<double> right) {
+    if (left.length != right.length) {
+      throw "The output buffers for the left and right must be the same length.";
+    }
+
+    var wrote = 0;
+    while (wrote < left.length) {
+      if (_blockWrote == synthesizer.blockSize) {
+        _processEvents();
+        _blockWrote = 0;
+        _currentTime += MidiFile.getTimeSpanFromSeconds(
+            _speed * synthesizer.blockSize / synthesizer.sampleRate);
+      }
+
+      var srcRem = synthesizer.blockSize - _blockWrote;
+      var dstRem = left.length - wrote;
+      var rem = math.min(srcRem, dstRem);
+
+      synthesizer.render(left.slice(wrote, rem), right.slice(wrote, rem));
+
+      _blockWrote += rem;
+      wrote += rem;
+    }
+  }
+
+  void _processEvents() {
+    if (_midiFile == null) {
+      return;
+    }
+
+    while (_msgIndex < _midiFile!.messages.length) {
+      var time = _midiFile!.times[_msgIndex];
+      var msg = _midiFile!.messages[_msgIndex];
+      if (time <= _currentTime) {
+        if (msg.type == MidiMessageType.normal) {
+          if (onSendMessage == null) {
+            synthesizer.processMidiMessage(
+                channel: msg.channel,
+                command: msg.command,
+                data1: msg.data1,
+                data2: msg.data2);
+          } else {
+            onSendMessage!(
+                synthesizer, msg.channel, msg.command, msg.data1, msg.data2);
+          }
+        } else if (_loop == true) {
+          if (msg.type == MidiMessageType.loopStart) {
+            _loopIndex = _msgIndex;
+          } else if (msg.type == MidiMessageType.loopEnd) {
+            _currentTime = _midiFile!.times[_loopIndex];
+            _msgIndex = _loopIndex;
+            synthesizer.noteOffAll();
+          }
+        }
+        _msgIndex++;
+      } else {
+        break;
+      }
+    }
+
+    if (_msgIndex == _midiFile!.messages.length && _loop == true) {
+      _currentTime = _midiFile!.times[_loopIndex];
+      _msgIndex = _loopIndex;
+      synthesizer.noteOffAll();
+    }
+  }
+
+  /// <summary>
+  /// Gets the currently playing MIDI file.
+  /// </summary>
+  MidiFile? get midiFile => _midiFile;
+
+  /// <summary>
+  /// Gets the current playback position.
+  /// </summary>
+  Duration get position => _currentTime;
+
+  /// <summary>
+  /// Gets a value that indicates whether the current playback position is at the end of the sequence.
+  /// </summary>
+  /// <remarks>
+  /// If the <see cref="Play(MidiFile, bool)">Play</see> method has not yet been called, this value is true.
+  /// This value will never be <c>true</c> when loop playback is enabled.
+  /// </remarks>
+  bool get endOfSequence {
+    if (midiFile == null) {
+      return true;
+    } else {
+      return _msgIndex == midiFile!.messages.length;
+    }
+  }
+
+  /// <summary>
+  /// Gets or sets the playback speed.
+  /// </summary>
+  /// <remarks>
+  /// The default value is 1.
+  /// The tempo will be multiplied by this value.
+  /// </remarks>
+  double get speed => _speed;
+
+  set speed(double value) {
+    if (value >= 0) {
+      speed = value;
+    } else {
+      throw "The playback speed must be a non-negative value.";
+    }
+  }
+}
+
+/// <summary>
+/// Represents the method that is called each time a MIDI message is processed during playback.
+/// </summary>
+/// <param name="synthesizer">The synthesizer used by the sequencer.</param>
+/// <param name="channel">The channel to which the message will be sent.</param>
+/// <param name="command">The type of the message.</param>
+/// <param name="data1">The first data part of the message.</param>
+/// <param name="data2">The second data part of the message.</param>
+typedef MessageHook = void Function(
+  Synthesizer synthesizer,
+  int channel,
+  int command,
+  int data1,
+  int data2,
+);

--- a/lib/midi_file_sequencer.dart
+++ b/lib/midi_file_sequencer.dart
@@ -1,9 +1,10 @@
-import 'package:dart_melty_soundfont/audio_renderer.dart';
-import 'package:dart_melty_soundfont/list_slice.dart';
+import 'dart:math' as math;
 
 import 'midi_file.dart';
 import 'synthesizer.dart';
-import 'dart:math' as math;
+import 'audio_renderer.dart';
+import 'list_slice.dart';
+
 
 /// <summary>
 /// An instance of the MIDI file sequencer.

--- a/lib/synthesizer.dart
+++ b/lib/synthesizer.dart
@@ -1,6 +1,7 @@
 ﻿import 'dart:math';
 import 'dart:typed_data';
 
+import 'audio_renderer.dart';
 import 'soundfont.dart';
 import 'channel.dart';
 import 'voice.dart';
@@ -19,7 +20,7 @@ import 'soundfont_math.dart';
 /// Note: that this class does not provide thread safety.
 /// If you want to send notes and render the waveform in separate threads,
 /// you must ensure that the methods will not be called simultaneously.
-class Synthesizer {
+class Synthesizer implements AudioRenderer {
   // Public:
 
   static const int channelCount = 16;


### PR DESCRIPTION
Following issue [#14](https://github.com/chipweinberger/dart_melty_soundfont/issues/14), I incorporated MIDI file support on my fork, taken from sinshu's [meltysynth](https://github.com/sinshu/meltysynth), and made necessary adjustments to make it work on Dart.

Example usage:
```dart
final sequencer = MidiFileSequencer(synth);
final midiFile = MidiFile.fromByteData(await rootBundle.load('assets/chpn_op23.mid'));
sequencer.play(midiFile);

final buf16 = ArrayInt16.zeros(numShorts: 1000);
sequencer.renderMonoInt16(buf16);
```

The logic behind it is mostly keep unchanged, so most of the MIDI files out there should work (at least on my case). Tested with single track classical pieces and multi-track GM songs.

I haven't updated the example app code, let me know if you would like those changes as well.