### PR TITLE
Slightly awkward system for controlling playback time

### DIFF
--- a/lib/midi_file_sequencer.dart
+++ b/lib/midi_file_sequencer.dart
@@ -166,7 +166,29 @@ class MidiFileSequencer implements AudioRenderer {
       throw "The playback speed must be a non-negative value.";
     }
   }
+
+  /// <summary>
+  /// Gets or sets the current playback time.
+  /// </summary>
+  /// <remarks>
+  /// This can be used to fast forward or rewind the playback.
+  /// In the case of rewinding, the sequencer will have to internally reset and 
+  /// reprocess all notes from the beginning.
+  /// </remarks>
+  Duration get time => _currentTime;
+
+  set time(Duration time) {
+    if (time < _currentTime) {
+      _msgIndex = 0;
+      synthesizer.reset();
+    }
+    
+    _currentTime = time;
+
+    _processEvents();
+  }
 }
+
 
 /// <summary>
 /// Represents the method that is called each time a MIDI message is processed during playback.

--- a/lib/voice_collection.dart
+++ b/lib/voice_collection.dart
@@ -95,7 +95,7 @@ class VoiceCollection extends Iterable<Voice> {
   int activeVoiceCount() => _activeVoiceCount;
 }
 
-class VoiceIterator extends Iterator<Voice> {
+class VoiceIterator implements Iterator<Voice> {
   final VoiceCollection collection;
 
   int _index = 0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_melty_soundfont
 description: A Soundfont synthesizer (i.e. '.sf2' player) written in pure Dart.
-version: 1.1.16
+version: 1.1.17
 homepage: https://github.com/chipweinberger/dart_melty_soundfont
 
 


### PR DESCRIPTION
Hi, not sure if you have any interest in this feature, but my app invokes playing a MIDI keyboard along with a MIDI track, so I need to control time explicitly, and this PR adds a simple API for that using a "time" property.

The awkward part is deciding when to reset the synth - you obviously want to do it when rewinding, but you may also want to do it when skipping forward, as opposed to just advancing time normally. 

Perhaps a "seek" API would be better which implicitly resets the synth, but I also need to be able to advance time manually for my use case without the reset.

Anyway, thanks for making this package, it's been very helpful.