### PR TITLE
Change List<double> to Float32List for nearly 2x performance.

### DIFF
--- a/lib/array_math.dart
+++ b/lib/array_math.dart
@@ -1,4 +1,6 @@
-void multiplyAdd({required double factorA, required List<double> factorB, required List<double> dest}) {
+import 'dart:typed_data';
+
+void multiplyAdd({required double factorA, required Float32List factorB, required Float32List dest}) {
   assert(factorB.length == dest.length);
 
   for (var i = 0; i < dest.length; i++) {
@@ -7,7 +9,7 @@ void multiplyAdd({required double factorA, required List<double> factorB, requir
 }
 
 void multiplyAddStep(
-    {required double factorA, required double step, required List<double> factorB, required List<double> dest}) {
+    {required double factorA, required double step, required Float32List factorB, required Float32List dest}) {
   for (var i = 0; i < dest.length; i++) {
     dest[i] += factorA * factorB[i];
     factorA += step;

--- a/lib/audio_renderer.dart
+++ b/lib/audio_renderer.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 /// <summary>
 /// Defines a common interface for audio rendering.
 /// </summary>
@@ -10,5 +12,5 @@ abstract class AudioRenderer {
   /// <remarks>
   /// The output buffers for the left and right must be the same length.
   /// </remarks>
-  void render(List<double> left, List<double> right);
+  void render(Float32List left, Float32List right);
 }

--- a/lib/audio_renderer_ex.dart
+++ b/lib/audio_renderer_ex.dart
@@ -1,4 +1,6 @@
-﻿import 'audio_renderer.dart';
+﻿import 'dart:typed_data';
+
+import 'audio_renderer.dart';
 import 'array_int16.dart';
 
 /// Provides utility methods to convert the format of samples.
@@ -14,7 +16,7 @@ extension AudioRenderEx on AudioRenderer {
   /// To completely avoid memory allocation,
   /// use <see cref="IAudioRenderer.Render(Span{float}, Span{float})"/>.
   /// </remarks>
-  void renderInterleaved(List<double> destination, {int offset = 0, int? length}) {
+  void renderInterleaved(Float32List destination, {int offset = 0, int? length}) {
     if (destination.length % 2 != 0) {
       throw "The length of the destination buffer must be even.";
     }
@@ -28,8 +30,8 @@ extension AudioRenderEx on AudioRenderer {
       sampleCount -= offset;
     }
 
-    List<double> left = List<double>.filled(sampleCount, 0, growable: false);
-    List<double> right = List<double>.filled(sampleCount, 0, growable: false);
+    final left = Float32List(sampleCount);
+    final right = Float32List(sampleCount);
 
     render(left, right);
 
@@ -50,13 +52,13 @@ extension AudioRenderEx on AudioRenderer {
   /// To completely avoid memory allocation,
   /// use <see cref="IAudioRenderer.Render(Span{float}, Span{float})"/>.
   /// </remarks>
-  void renderMono(List<double> destination, {int offset = 0}) {
+  void renderMono(Float32List destination, {int offset = 0}) {
     int sampleCount = destination.length ~/ 2;
 
     sampleCount -= offset;
 
-    List<double> left = List<double>.filled(sampleCount, 0, growable: false);
-    List<double> right = List<double>.filled(sampleCount, 0, growable: false);
+    final left = Float32List(sampleCount);
+    final right = Float32List(sampleCount);
 
     render(left, right);
 
@@ -91,8 +93,8 @@ extension AudioRenderEx on AudioRenderer {
       sampleCount -= offset;
     }
 
-    List<double> left = List<double>.filled(sampleCount, 0, growable: false);
-    List<double> right = List<double>.filled(sampleCount, 0, growable: false);
+    final left = Float32List(sampleCount);
+    final right = Float32List(sampleCount);
 
     render(left, right);
 
@@ -132,8 +134,8 @@ extension AudioRenderEx on AudioRenderer {
       sampleCount -= offset;
     }
 
-    List<double> left = List<double>.filled(sampleCount, 0, growable: false);
-    List<double> right = List<double>.filled(sampleCount, 0, growable: false);
+    final left = Float32List(sampleCount);
+    final right = Float32List(sampleCount);
 
     render(left, right);
 

--- a/lib/bi_quad_filter.dart
+++ b/lib/bi_quad_filter.dart
@@ -1,4 +1,5 @@
 ﻿import 'dart:math';
+import 'dart:typed_data';
 import 'synthesizer.dart';
 
 class BiQuadFilter {
@@ -62,7 +63,7 @@ class BiQuadFilter {
     }
   }
 
-  void process(List<double> block) {
+  void process(Float32List block) {
     if (_active) {
       for (var t = 0; t < block.length; t++) {
         var input = block[t];

--- a/lib/channel.dart
+++ b/lib/channel.dart
@@ -1,12 +1,14 @@
-﻿import 'soundfont_math.dart';
+﻿import 'dart:typed_data';
+
+import 'soundfont_math.dart';
 import 'synthesizer.dart';
 
 class Channel {
   final Synthesizer synthesizer;
   final bool isPercussionChannel;
 
-  final List<double> blockLeft;
-  final List<double> blockRight;
+  final Float32List blockLeft;
+  final Float32List blockRight;
 
   int _bankNumber;
   int _patchNumber;
@@ -68,8 +70,8 @@ class Channel {
     Channel c = Channel(
         synthesizer: synthesizer,
         isPercussionChannel: isPercussionChannel,
-        blockLeft: List<double>.filled(synthesizer.blockSize, 0.0),
-        blockRight: List<double>.filled(synthesizer.blockSize, 0.0),
+        blockLeft: Float32List(synthesizer.blockSize),
+        blockRight: Float32List(synthesizer.blockSize),
         bankNumber: 0,
         patchNumber: 0,
         modulation: 0,

--- a/lib/chorus.dart
+++ b/lib/chorus.dart
@@ -1,10 +1,11 @@
 ﻿import 'dart:math';
+import 'dart:typed_data';
 
 class Chorus {
-  final List<double> _bufferL;
-  final List<double> _bufferR;
+  final Float32List _bufferL;
+  final Float32List _bufferR;
 
-  final List<double> _delayTable;
+  final Float32List _delayTable;
 
   int _bufferIndexL;
   int _bufferIndexR;
@@ -13,9 +14,9 @@ class Chorus {
   int _delayTableIndexR;
 
   Chorus(
-      {required List<double> bufferL,
-      required List<double> bufferR,
-      required List<double> delayTable,
+      {required Float32List bufferL,
+      required Float32List bufferR,
+      required Float32List delayTable,
       required int bufferIndexL,
       required int bufferIndexR,
       required int delayTableIndexL,
@@ -30,7 +31,7 @@ class Chorus {
 
   factory Chorus.create(
       {required int sampleRate, required double delay, required double depth, required double frequency}) {
-    List<double> delayTable = List<double>.filled((sampleRate / frequency).round(), 0);
+    Float32List delayTable = Float32List((sampleRate / frequency).round());
 
     for (var t = 0; t < delayTable.length; t++) {
       var phase = 2 * pi * t / delayTable.length;
@@ -40,8 +41,8 @@ class Chorus {
     int sampleCount = ((sampleRate * (delay + depth)) + 2).toInt();
 
     return Chorus(
-        bufferL: List<double>.filled(sampleCount, 0),
-        bufferR: List<double>.filled(sampleCount, 0),
+        bufferL: Float32List(sampleCount),
+        bufferR: Float32List(sampleCount),
         delayTable: delayTable,
         bufferIndexL: 0,
         bufferIndexR: 0,
@@ -50,10 +51,10 @@ class Chorus {
   }
 
   void process(
-      {required List<double> inputLeft,
-      required List<double> inputRight,
-      required List<double> outputLeft,
-      required List<double> outputRight}) {
+      {required Float32List inputLeft,
+      required Float32List inputRight,
+      required Float32List outputLeft,
+      required Float32List outputRight}) {
     for (int t = 0; t < outputLeft.length; t++) {
       double position = _bufferIndexL - _delayTable[_delayTableIndexL];
       if (position < 0.0) {

--- a/lib/midi_file_sequencer.dart
+++ b/lib/midi_file_sequencer.dart
@@ -1,9 +1,9 @@
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'midi_file.dart';
 import 'synthesizer.dart';
 import 'audio_renderer.dart';
-import 'list_slice.dart';
 
 /// <summary>
 /// An instance of the MIDI file sequencer.
@@ -63,7 +63,7 @@ class MidiFileSequencer implements AudioRenderer {
   }
 
   /// <inheritdoc/>
-  void render(List<double> left, List<double> right) {
+  void render(Float32List left, Float32List right) {
     if (left.length != right.length) {
       throw "The output buffers for the left and right must be the same length.";
     }
@@ -80,7 +80,10 @@ class MidiFileSequencer implements AudioRenderer {
       var dstRem = left.length - wrote;
       var rem = math.min(srcRem, dstRem);
 
-      synthesizer.render(left.slice(wrote, rem), right.slice(wrote, rem));
+      // Create Float32List views for the slices
+      var leftSlice = Float32List.view(left.buffer, wrote * 4, rem);
+      var rightSlice = Float32List.view(right.buffer, wrote * 4, rem);
+      synthesizer.render(leftSlice, rightSlice);
 
       _blockWrote += rem;
       wrote += rem;

--- a/lib/oscillator.dart
+++ b/lib/oscillator.dart
@@ -1,4 +1,5 @@
 ﻿import 'dart:math';
+import 'dart:typed_data';
 
 import 'array_int16.dart';
 import 'synthesizer.dart';
@@ -62,13 +63,13 @@ class Oscillator {
     }
   }
 
-  bool process(List<double> block, double pitch) {
+  bool process(Float32List block, double pitch) {
     double pitchChange = _pitchChangeScale * (pitch - _rootKey) + _tune;
     double pitchRatio = _sampleRateRatio * pow(2, pitchChange / 12);
     return _fillBlock(block, pitchRatio);
   }
 
-  bool _fillBlock(List<double> block, double pitchRatio) {
+  bool _fillBlock(Float32List block, double pitchRatio) {
     if (_looping) {
       return _fillBlockContinuous(block, pitchRatio);
     } else {
@@ -76,7 +77,7 @@ class Oscillator {
     }
   }
 
-  bool _fillBlockNoLoop(List<double> block, double pitchRatio) {
+  bool _fillBlockNoLoop(Float32List block, double pitchRatio) {
     for (var t = 0; t < block.length; t++) {
       int index = _position.toInt();
 
@@ -105,7 +106,7 @@ class Oscillator {
     return true;
   }
 
-  bool _fillBlockContinuous(List<double> block, double pitchRatio) {
+  bool _fillBlockContinuous(Float32List block, double pitchRatio) {
     double endLoopPosition = _endLoop.toDouble();
 
     int loopLength = _endLoop - _startLoop;

--- a/lib/reverb.dart
+++ b/lib/reverb.dart
@@ -1,4 +1,6 @@
-﻿import 'reverb_comb_filter.dart';
+﻿import 'dart:typed_data';
+
+import 'reverb_comb_filter.dart';
 import 'reverb_all_pass_filter.dart';
 
 // This reverb implementation is based on Freeverb, a domain reverb
@@ -117,7 +119,7 @@ class Reverb {
     return r;
   }
 
-  void process(List<double> input, List<double> outputLeft, List<double> outputRight) {
+  void process(Float32List input, Float32List outputLeft, Float32List outputRight) {
     outputLeft.fillRange(0, outputLeft.length, 0.0);
     outputRight.fillRange(0, outputRight.length, 0.0);
 

--- a/lib/reverb_all_pass_filter.dart
+++ b/lib/reverb_all_pass_filter.dart
@@ -1,7 +1,8 @@
 import 'dart:math';
+import 'dart:typed_data';
 
 class AllPassFilter {
-  final List<double> buffer;
+  final Float32List buffer;
 
   int _bufferIndex;
 
@@ -9,7 +10,7 @@ class AllPassFilter {
   double feedback;
 
   AllPassFilter({required int bufferSize})
-      : buffer = List<double>.filled(bufferSize, 0.0),
+      : buffer = Float32List(bufferSize),
         _bufferIndex = 0,
         feedback = 0.0;
 
@@ -17,7 +18,7 @@ class AllPassFilter {
     buffer.fillRange(0, buffer.length, 0.0);
   }
 
-  void process(List<double> block) {
+  void process(Float32List block) {
     int blockIndex = 0;
     while (blockIndex < block.length) {
       if (_bufferIndex == buffer.length) {

--- a/lib/reverb_comb_filter.dart
+++ b/lib/reverb_comb_filter.dart
@@ -1,7 +1,8 @@
 import 'dart:math';
+import 'dart:typed_data';
 
 class CombFilter {
-  final List<double> buffer;
+  final Float32List buffer;
 
   int _bufferIndex;
   double _filterStore;
@@ -11,7 +12,7 @@ class CombFilter {
   double _damp2;
 
   CombFilter({required int bufferSize})
-      : buffer = List<double>.filled(bufferSize, 0.0),
+      : buffer = Float32List(bufferSize),
         _bufferIndex = 0,
         _filterStore = 0.0,
         feedback = 0.0,
@@ -30,7 +31,7 @@ class CombFilter {
     _damp2 = 1.0 - v;
   }
 
-  void process(List<double> inputBlock, List<double> outputBlock) {
+  void process(Float32List inputBlock, Float32List outputBlock) {
     int blockIndex = 0;
     while (blockIndex < outputBlock.length) {
       if (_bufferIndex == buffer.length) {

--- a/lib/synthesizer.dart
+++ b/lib/synthesizer.dart
@@ -48,23 +48,23 @@ class Synthesizer implements AudioRenderer {
   final Map<int, Preset> _presetLookup;
   final Preset _defaultPreset;
 
-  final List<double> _blockLeft;
-  final List<double> _blockRight;
+  final Float32List _blockLeft;
+  final Float32List _blockRight;
 
   final double _inverseBlockSize;
 
   final bool _enableReverbAndChorus;
 
   final Reverb? _reverb;
-  final List<double>? _reverbInput;
-  final List<double>? _reverbOutputLeft;
-  final List<double>? _reverbOutputRight;
+  final Float32List? _reverbInput;
+  final Float32List? _reverbOutputLeft;
+  final Float32List? _reverbOutputRight;
 
   final Chorus? _chorus;
-  final List<double>? _chorusInputLeft;
-  final List<double>? _chorusInputRight;
-  final List<double>? _chorusOutputLeft;
-  final List<double>? _chorusOutputRight;
+  final Float32List? _chorusInputLeft;
+  final Float32List? _chorusInputRight;
+  final Float32List? _chorusOutputLeft;
+  final Float32List? _chorusOutputRight;
 
   int _blockRead;
 
@@ -77,20 +77,20 @@ class Synthesizer implements AudioRenderer {
     required this.masterVolume,
     required Map<int, Preset> presetLookup,
     required Preset defaultPreset,
-    required List<double> blockLeft,
-    required List<double> blockRight,
+    required Float32List blockLeft,
+    required Float32List blockRight,
     required double inverseBlockSize,
     required int blockRead,
     required bool enableReverbAndChorus,
     required Reverb? reverb,
-    required List<double>? reverbInput,
-    required List<double>? reverbOutputLeft,
-    required List<double>? reverbOutputRight,
+    required Float32List? reverbInput,
+    required Float32List? reverbOutputLeft,
+    required Float32List? reverbOutputRight,
     required Chorus? chorus,
-    required List<double>? chorusInputLeft,
-    required List<double>? chorusInputRight,
-    required List<double>? chorusOutputLeft,
-    required List<double>? chorusOutputRight,
+    required Float32List? chorusInputLeft,
+    required Float32List? chorusInputRight,
+    required Float32List? chorusOutputLeft,
+    required Float32List? chorusOutputRight,
   })  : _presetLookup = presetLookup,
         _defaultPreset = defaultPreset,
         _blockLeft = blockLeft,
@@ -156,19 +156,19 @@ class Synthesizer implements AudioRenderer {
       minimumVoiceDuration: settings.sampleRate ~/ 500,
       presetLookup: presetLookup,
       defaultPreset: defaultPreset!,
-      blockLeft: List<double>.filled(settings.blockSize, 0),
-      blockRight: List<double>.filled(settings.blockSize, 0),
+      blockLeft: Float32List(settings.blockSize),
+      blockRight: Float32List(settings.blockSize),
       inverseBlockSize: 1.0 / settings.blockSize,
       blockRead: settings.blockSize,
       reverb: !rc ? null : Reverb.withSampleRate(settings.sampleRate),
-      reverbInput: !rc ? null : List<double>.filled(settings.blockSize, 0),
-      reverbOutputLeft: !rc ? null : List<double>.filled(settings.blockSize, 0),
-      reverbOutputRight: !rc ? null : List<double>.filled(settings.blockSize, 0),
+      reverbInput: !rc ? null : Float32List(settings.blockSize),
+      reverbOutputLeft: !rc ? null : Float32List(settings.blockSize),
+      reverbOutputRight: !rc ? null : Float32List(settings.blockSize),
       chorus: chorus,
-      chorusInputLeft: !rc ? null : List<double>.filled(settings.blockSize, 0),
-      chorusInputRight: !rc ? null : List<double>.filled(settings.blockSize, 0),
-      chorusOutputLeft: !rc ? null : List<double>.filled(settings.blockSize, 0),
-      chorusOutputRight: !rc ? null : List<double>.filled(settings.blockSize, 0),
+      chorusInputLeft: !rc ? null : Float32List(settings.blockSize),
+      chorusInputRight: !rc ? null : Float32List(settings.blockSize),
+      chorusOutputLeft: !rc ? null : Float32List(settings.blockSize),
+      chorusOutputRight: !rc ? null : Float32List(settings.blockSize),
       masterVolume: 0.5,
     );
 
@@ -420,7 +420,7 @@ class Synthesizer implements AudioRenderer {
   }
 
   /// <inheritdoc/>
-  void render(List<double> left, List<double> right) {
+  void render(Float32List left, Float32List right) {
     if (left.length != right.length) {
       throw "The output buffers must be the same length.";
     }
@@ -510,7 +510,7 @@ class Synthesizer implements AudioRenderer {
     }
   }
 
-  void _writeBlock(double previousGain, double currentGain, List<double> source, List<double> destination) {
+  void _writeBlock(double previousGain, double currentGain, Float32List source, Float32List destination) {
     if (max(previousGain, currentGain) < SoundFontMath.nonAudible) {
       return;
     }

--- a/lib/voice.dart
+++ b/lib/voice.dart
@@ -1,4 +1,6 @@
-﻿import 'modulation_envelope.dart';
+﻿import 'dart:typed_data';
+
+import 'modulation_envelope.dart';
 import 'volume_envelope.dart';
 import 'lfo.dart';
 import 'oscillator.dart';
@@ -24,7 +26,7 @@ class Voice {
   final Oscillator _oscillator;
   final BiQuadFilter _filter;
 
-  final List<double> _block;
+  final Float32List _block;
 
   // A sudden change in the mix gain will cause pop noise.
   // To avoid this, we save the mix gain of the previous block,
@@ -82,7 +84,7 @@ class Voice {
         _modLfo = Lfo(synthesizer),
         _oscillator = Oscillator(synthesizer),
         _filter = BiQuadFilter(synthesizer),
-        _block = List<double>.filled(synthesizer.blockSize, 0.0);
+        _block = Float32List(synthesizer.blockSize);
 
   void start(RegionPair region, int channel, int key, int velocity) {
     _exclusiveClass = region.exclusiveClass();
@@ -277,7 +279,7 @@ class Voice {
     }
   }
 
-  List<double> block() => _block;
+  Float32List block() => _block;
 
   double previousMixGainLeft() => _previousMixGainLeft;
   double previousMixGainRight() => _previousMixGainRight;


### PR DESCRIPTION
Hi, nice lib!

Inspired by [this PR](https://github.com/chipweinberger/dart_melty_soundfont/pull/31), this one replaces occurrences of `List<double>` with `Float32List`, without introducing any formatting changes.

I also didn’t remove the ArrayInt16 class, so this PR introduces no breaking changes and requires no updates to the example code.

I tested it in my project and confirmed that render time is nearly halved with these changes.

Let me know if you'd like anything adjusted. Best regards!