### PR TITLE
Fix midi loop message types to make midi sequencer looping functionality work correctly.

### DIFF
--- a/lib/midi_file.dart
+++ b/lib/midi_file.dart
@@ -347,9 +347,9 @@ class MidiMessage {
       return MidiMessageType.tempoChange;
     } else if (channel == MidiMessageType.loopStart.value) {
       return MidiMessageType.loopStart;
-    } else if (channel == MidiMessageType.loopEnd) {
+    } else if (channel == MidiMessageType.loopEnd.value) {
       return MidiMessageType.loopEnd;
-    } else if (channel == MidiMessageType.endOfTrack) {
+    } else if (channel == MidiMessageType.endOfTrack.value) {
       return MidiMessageType.endOfTrack;
     } else {
       return MidiMessageType.normal;


### PR DESCRIPTION
Small fix for to make the looping work. Otherwise, it basically treats loop end and end of track messages as normal and doesn't trigger looping.