### PR TITLE
Enhance time tracking in MidiFileSequencer to prevent rounding errors

### DIFF
--- a/lib/midi_file_sequencer.dart
+++ b/lib/midi_file_sequencer.dart
@@ -24,6 +24,7 @@ class MidiFileSequencer implements AudioRenderer {
   int _blockWrote = 0;
 
   Duration _currentTime = Duration.zero;
+  double _currentTimeUs = 0.0;
   int _msgIndex = 0;
   int _loopIndex = 0;
 
@@ -47,6 +48,7 @@ class MidiFileSequencer implements AudioRenderer {
     _blockWrote = synthesizer.blockSize;
 
     _currentTime = Duration.zero;
+    _currentTimeUs = 0.0;
     _msgIndex = 0;
     _loopIndex = 0;
 
@@ -73,7 +75,9 @@ class MidiFileSequencer implements AudioRenderer {
       if (_blockWrote == synthesizer.blockSize) {
         _processEvents();
         _blockWrote = 0;
-        _currentTime += MidiFile.getTimeSpanFromSeconds(_speed * synthesizer.blockSize / synthesizer.sampleRate);
+        // Track time accurately with double to prevent accumulation of rounding errors
+        _currentTimeUs += (_speed * synthesizer.blockSize * Duration.microsecondsPerSecond / synthesizer.sampleRate);
+        _currentTime = Duration(microseconds: _currentTimeUs.round());
       }
 
       var srcRem = synthesizer.blockSize - _blockWrote;
@@ -111,6 +115,7 @@ class MidiFileSequencer implements AudioRenderer {
             _loopIndex = _msgIndex;
           } else if (msg.type == MidiMessageType.loopEnd) {
             _currentTime = _midiFile!.times[_loopIndex];
+            _currentTimeUs = _currentTime.inMicroseconds.toDouble();
             _msgIndex = _loopIndex;
             synthesizer.noteOffAll();
           }
@@ -123,6 +128,7 @@ class MidiFileSequencer implements AudioRenderer {
 
     if (_msgIndex == _midiFile!.messages.length && _loop == true) {
       _currentTime = _midiFile!.times[_loopIndex];
+      _currentTimeUs = _currentTime.inMicroseconds.toDouble();
       _msgIndex = _loopIndex;
       synthesizer.noteOffAll();
     }


### PR DESCRIPTION
Issue: getTimeSpanFromSeconds() returns a Duration, which stores time as integer microseconds.

At 44100 Hz with block size 64:
Actual time per block: 1451.247166... microseconds
Stored as Duration: 1451 microseconds (truncated)
Lost per block: 0.247166 microseconds
Over 15 minutes, this tiny error accumulates to ~150ms of drift - which is already noticeable.

The fix is to use double for current time in microseconds to avoid accumulating rounding errors.