### PR TITLE
fix(web): use JS-safe sentinel for minTick to enable dart2js compilation

### DIFF
--- a/lib/midi_file.dart
+++ b/lib/midi_file.dart
@@ -192,7 +192,11 @@ class MidiFile {
     double tempo = 120.0;
 
     while (true) {
-      int minTick = 0x7fffffffffffffff; // int max value
+      // Use a JS-safe sentinel (2^53 - 1) instead of the 64-bit int max
+      // (0x7fffffffffffffff), which dart2js cannot represent and fails to
+      // compile for the web. MIDI ticks never approach this magnitude, so the
+      // "find the minimum tick" logic below is unaffected.
+      int minTick = 0x1fffffffffffff; // == 9007199254740991 (maxSafeInteger)
       int minIndex = -1;
       for (int ch = 0; ch < tickLists.length; ch++) {
         if (indices[ch] < tickLists[ch].length) {


### PR DESCRIPTION
The 64-bit int literal 0x7fffffffffffffff in MidiFile.merge() cannot be represented exactly in JavaScript, so dart2js fails to compile any web app that depends on this package:

    Error: The integer literal 0x7fffffffffffffff can't be represented
    exactly in JavaScript.

Replace it with 0x1fffffffffffff (2^53-1, JS maxSafeInteger), which is a valid web int literal and still far larger than any real MIDI tick value, so the minimum-tick search is unaffected. Native (dart:io) behaviour is unchanged.